### PR TITLE
Migrate from bind mounts to volumes (Docker-compose)

### DIFF
--- a/clear.sh
+++ b/clear.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-docker-compose down
-rm -rf ./volumes
+docker-compose down --volumes
 docker-compose pull

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,7 @@ services:
       - "8545:8545"
       - "8546:8546"
     volumes:
-      - type: bind
-        source: ./volumes/geth
-        target: /var/lib/geth/data
+      - geth:/var/lib/geth/data
   postgres:
     image: "postgres:12"
     logging:
@@ -18,9 +16,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - type: bind
-        source: ./volumes/postgres
-        target: /var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   zksync:
@@ -35,13 +31,15 @@ services:
       - "3051:3051" # JSON RPC WS port
     volumes:
       # Configs folder bind
-      - type: bind
-        source: ./volumes/zksync/env.env
-        target: /etc/env/dev.env
+      - zksync-config:/etc/env/
       # Storage folder bind
-      - type: bind
-        source: ./volumes/zksync/data
-        target: /var/lib/zksync/data
+      - zksync-data:/var/lib/zksync/data
     environment:
       - DATABASE_URL=postgres://postgres@postgres/zksync_local
       - ETH_CLIENT_WEB3_URL=http://geth:8545
+
+volumes:
+  geth:
+  postgres:
+  zksync-config:
+  zksync-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "8545:8545"
       - "8546:8546"
     volumes:
-      - geth:/var/lib/geth/data
+      - /var/lib/geth/data
   postgres:
     image: "postgres:12"
     logging:
@@ -16,7 +16,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - /var/lib/postgresql/data
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   zksync:
@@ -31,9 +31,9 @@ services:
       - "3051:3051" # JSON RPC WS port
     volumes:
       # Configs folder bind
-      - zksync-config:/etc/env/
+      - /etc/env/
       # Storage folder bind
-      - zksync-data:/var/lib/zksync/data
+      - /var/lib/zksync/data
     environment:
       - DATABASE_URL=postgres://postgres@postgres/zksync_local
       - ETH_CLIENT_WEB3_URL=http://geth:8545

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "8545:8545"
       - "8546:8546"
     volumes:
-      - /var/lib/geth/data
+      - geth:/var/lib/geth/data
   postgres:
     image: "postgres:12"
     logging:
@@ -16,7 +16,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - /var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   zksync:
@@ -31,9 +31,9 @@ services:
       - "3051:3051" # JSON RPC WS port
     volumes:
       # Configs folder bind
-      - /etc/env/
+      - zksync-config:/etc/env/
       # Storage folder bind
-      - /var/lib/zksync/data
+      - zksync-data:/var/lib/zksync/data
     environment:
       - DATABASE_URL=postgres://postgres@postgres/zksync_local
       - ETH_CLIENT_WEB3_URL=http://geth:8545

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 
-mkdir -p ./volumes
-mkdir -p ./volumes/postgres ./volumes/geth ./volumes/zksync/env/dev ./volumes/zksync/data
-touch ./volumes/zksync/env.env
-
 docker-compose up
 


### PR DESCRIPTION
Fixes the [bind mounts][1] corruption issues by replacing them with docker [volumes][2]. This allows us to manipulate the nodes directly with the `docker-compose` subcommands.

## Changes made:

- Implemented the use of named volumes to allow docker to handle persistent state management.
- Modified scripts to reflect this change in state management.

[1]: https://docs.docker.com/storage/bind-mounts/
[2]: https://docs.docker.com/storage/volumes/

closes #1 